### PR TITLE
Move `MessageFormat` into `messageformat` submodule

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,11 +2,16 @@
 API
 ===
 
-.. currentmodule:: icu4py
+``icu4py.messageformat``
+========================
+
+This module wraps ICU’s MessageFormat V1 functionality.
+
+.. currentmodule:: icu4py.messageformat
 
 .. class:: MessageFormat(pattern: str, locale: str)
 
-  A wrapper around ICU’s |MessageFormat class|__ (version 1).
+  A wrapper around ICU’s version 1 |MessageFormat class|__.
 
   .. |MessageFormat class| replace:: ``MessageFormat`` class
   __ https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1MessageFormat.html

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if sys.platform == "darwin":
 setup(
     ext_modules=[
         Extension(
-            "icu4py._ext",
-            sources=["src/icu4py/_ext.cpp"],
+            "icu4py.messageformat",
+            sources=["src/icu4py/messageformat.cpp"],
             libraries=libraries,
             extra_compile_args=extra_compile_args,
             extra_link_args=extra_link_args,

--- a/src/icu4py/__init__.py
+++ b/src/icu4py/__init__.py
@@ -1,7 +1,0 @@
-from __future__ import annotations
-
-from icu4py._ext import MessageFormat
-
-__all__ = [
-    "MessageFormat",
-]

--- a/src/icu4py/messageformat.cpp
+++ b/src/icu4py/messageformat.cpp
@@ -215,7 +215,7 @@ PyMethodDef MessageFormat_methods[] = {
 
 PyTypeObject MessageFormatType = {
     PyVarObject_HEAD_INIT(nullptr, 0)
-    "icu4py._ext.MessageFormat", /* tp_name */
+    "icu4py.messageformat.MessageFormat", /* tp_name */
     sizeof(MessageFormatObject), /* tp_basicsize */
     0, /* tp_itemsize */
     reinterpret_cast<destructor>(MessageFormat_dealloc), /* tp_dealloc */
@@ -279,8 +279,8 @@ PyModuleDef_Slot icu_ext_slots[] = {
 
 PyModuleDef icumodule = {
     PyModuleDef_HEAD_INIT,
-    "icu4py._ext", /* m_name */
-    "Bindings to the ICU (International Components for Unicode) library (ICU4C).", /* m_doc */
+    "icu4py.messageformat", /* m_name */
+    "", /* m_doc */
     0, /* m_size */
     nullptr, /* m_methods */
     icu_ext_slots, /* m_slots */

--- a/tests/test_messageformat.py
+++ b/tests/test_messageformat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from icu4py import MessageFormat
+from icu4py.messageformat import MessageFormat
 
 
 class TestMessageFormat:


### PR DESCRIPTION
This future-proofs the structure to allow supporting MessageFormat V2 in a `messageformat2` submodule later.