### PR TITLE
Allow MessageFormat to be subclassed

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 
 * Expand :meth:`MessageFormat.format` to support ``decimal.Decimal``, ``date``, and ``datetime`` values.
 
+* Allow :class:`MessageFormat` to be subclassed.
+
 0.1.0 (2026-01-09)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Typing :: Typed",
 ]
+dependencies = [
+  "typing-extensions>=4.15",
+]
 urls.Changelog = "https://icu4py.readthedocs.io/en/latest/changelog.html"
 urls.Documentation = "https://icu4py.readthedocs.io/"
 urls.Funding = "https://adamj.eu/books/"

--- a/src/icu4py/messageformat.cpp
+++ b/src/icu4py/messageformat.cpp
@@ -369,7 +369,7 @@ PyType_Spec MessageFormat_spec = {
     "icu4py.messageformat.MessageFormat",
     sizeof(MessageFormatObject),
     0,
-    Py_TPFLAGS_DEFAULT,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
     MessageFormat_slots
 };
 

--- a/src/icu4py/messageformat.pyi
+++ b/src/icu4py/messageformat.pyi
@@ -1,8 +1,9 @@
 from datetime import date, datetime
 from decimal import Decimal
-from typing import final
 
-@final
+from typing_extensions import disjoint_base
+
+@disjoint_base
 class MessageFormat:
     def __init__(self, pattern: str, locale: str) -> None: ...
     def format(

--- a/tests/test_messageformat.py
+++ b/tests/test_messageformat.py
@@ -487,3 +487,17 @@ class TestMessageFormat:
         result = fmt.format({key_with_null: "value"})
 
         assert result == "value"
+
+    def test_inheritance(self):
+        pattern = "Hello, {name}!"
+
+        class CustomMessageFormat(MessageFormat):
+            def format(
+                self, params: dict[str, int | float | str | Decimal | date | datetime]
+            ) -> str:
+                original = super().format(params)
+                return original.upper()
+
+        fmt = CustomMessageFormat(pattern, "en_US")
+        result = fmt.format({"name": "World"})
+        assert result == "HELLO, WORLD!"

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,9 @@ wheels = [
 name = "icu4py"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
 
 [package.dev-dependencies]
 docs = [
@@ -319,6 +322,7 @@ test = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.15" }]
 
 [package.metadata.requires-dev]
 docs = [


### PR DESCRIPTION
I think it's weird that C-defined types don't support this by default.