### PR TITLE
Fully fork lazy loading by TYPE_CHECKING

### DIFF
--- a/src/icu4py/__init__.py
+++ b/src/icu4py/__init__.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-icu_version: str
-icu_version_info: tuple[int, int, int, int]
+if TYPE_CHECKING:
+    from icu4py._version import icu_version, icu_version_info
+else:
 
+    def __getattr__(name: str) -> Any:
+        if name == "icu_version":
+            from icu4py._version import icu_version
 
-def __getattr__(name: str) -> Any:
-    if name == "icu_version":
-        from icu4py._version import icu_version
+            return icu_version
+        elif name == "icu_version_info":
+            from icu4py._version import icu_version_info
 
-        return icu_version
-    elif name == "icu_version_info":
-        from icu4py._version import icu_version_info
-
-        return icu_version_info
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+            return icu_version_info
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 __all__ = ["icu_version", "icu_version_info"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ import icu4py
 class TestGetAttr:
     def test_getattr_unknown_attribute(self):
         with pytest.raises(AttributeError, match="has no attribute 'nonexistent'"):
-            icu4py.nonexistent  # noqa: B018
+            icu4py.nonexistent  # type: ignore[attr-defined]  # noqa: B018
 
 
 class TestVersionInfo:


### PR DESCRIPTION
Copy the pattern from Textual: https://github.com/Textualize/textual/blob/main/src/textual/__init__.py

This allows type checkers to correctly detect incorrect attribute access, and will hopefully fix a flaky stubtest failure seen on CI.