### PR TITLE
Fix intermittent stubtest failure

### DIFF
--- a/src/icu4py/__init__.py
+++ b/src/icu4py/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from icu4py._version import icu_version, icu_version_info
 else:
+    from typing import Any
 
     def __getattr__(name: str) -> Any:
         if name == "icu_version":


### PR DESCRIPTION
stubtest sees `Any` and finds it inconsistent:

```
py314-stubtest: commands[0]> stubtest icu4py
error: icu4py.Any is inconsistent, metaclass differs
Stub: in file /.../icu4py/__init__.py:146
N/A
Runtime: in file /.../typing.py:588
<class 'typing._AnyMeta'>

error: icu4py.Any.__new__ is inconsistent, stub does not have *args parameter "args"
Stub: in file /.../icu4py/__init__.py:118
def [Self] (cls: type[Self`0]) -> Self`0
Runtime: in file /.../typing.py:600
def (cls, *args, **kwargs)

Found 2 errors (checked 3 modules)
```

…so defer importing `Any` to the non-type-checking block.