### PR TITLE
Wrap ICU MessageFormat object use in critical section

### DIFF
--- a/src/icu4py/messageformat.cpp
+++ b/src/icu4py/messageformat.cpp
@@ -351,12 +351,21 @@ PyObject* MessageFormat_format(MessageFormatObject* self, PyObject* args) {
     UErrorCode status = U_ZERO_ERROR;
     UnicodeString result;
 
+    // ICU objects need external synchronization
+#ifdef Py_GIL_DISABLED
+    Py_BEGIN_CRITICAL_SECTION(self);
+#endif
+
     if (count == 0) {
         FieldPosition field_pos;
         result = self->formatter->format(nullptr, 0, result, field_pos, status);
     } else {
         result = self->formatter->format(argumentNames, arguments, count, result, status);
     }
+
+#ifdef Py_GIL_DISABLED
+    Py_END_CRITICAL_SECTION();
+#endif
 
     if (U_FAILURE(status)) {
         PyErr_Format(PyExc_RuntimeError, "Failed to format message: %s",


### PR DESCRIPTION
Per [docs](https://unicode-org.github.io/icu-docs/apidoc/released/icu4c/classicu_1_1MessageFormat.html#:~:text=MessageFormats%20are%20not%20synchronized%2E):

> MessageFormats are not synchronized. It is recommended to create separate format instances for each thread. If multiple threads access a format concurrently, it must be synchronized externally.